### PR TITLE
Modify PeptideSelect to use scan id as value

### DIFF
--- a/frontend/src/components/PeptideSelect.tsx
+++ b/frontend/src/components/PeptideSelect.tsx
@@ -10,7 +10,7 @@ import PeptideStore from "../stores/PeptideStore";
 
 const PeptideSelect = observer(() => {
   const handleChange = (event: SelectChangeEvent) => {
-    PeptideStore.setSelectedPeptide(event.target.value as string);
+    PeptideStore.setSelectedPeptideScanId(event.target.value as string);
   };
 
   return (
@@ -19,16 +19,15 @@ const PeptideSelect = observer(() => {
       <Select
         label="Select Peptide"
         labelId="peptide-select-label"
-        value={PeptideStore.selectedPeptide}
+        value={PeptideStore.selectedPeptideScanId}
         onChange={handleChange}
         displayEmpty
-        renderValue={(selected) => selected || <em>None selected</em>}
+        renderValue={(_) =>
+          PeptideStore.selectedPeptide?.Sequence || <em>None selected</em>
+        }
       >
         {PeptideStore.peptides.map((peptide, index) => (
-          <MenuItem
-            key={index}
-            value={`${peptide.Sequence} | ${peptide.Scan} | ${peptide.Modification}`}
-          >
+          <MenuItem key={index} value={peptide.Scan}>
             {`${peptide.Sequence} | Scan: ${peptide.Scan} | Mods: ${peptide.Modification}`}
           </MenuItem>
         ))}

--- a/frontend/src/stores/PeptideStore.ts
+++ b/frontend/src/stores/PeptideStore.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable } from "mobx";
+import { computed, makeAutoObservable } from "mobx";
 import Papa from "papaparse";
 
 interface Peptide {
@@ -10,7 +10,7 @@ interface Peptide {
 
 class PeptideStore {
   peptides: Peptide[] = [];
-  selectedPeptide: string = "";
+  selectedPeptideScanId: string = "";
   precursorCharge: number = 1;
   maxFragmentCharge: number = 1;
   fragmentTolerance: number = 10.0; // Default in ppm
@@ -20,12 +20,18 @@ class PeptideStore {
     makeAutoObservable(this);
   }
 
+  get selectedPeptide() {
+    return computed(() => {
+      return this.peptides.find((p) => p.Scan === this.selectedPeptideScanId);
+    }).get();
+  }
+
   setPeptides(peptides: Peptide[]) {
     this.peptides = peptides;
   }
 
-  setSelectedPeptide(peptide: string) {
-    this.selectedPeptide = peptide;
+  setSelectedPeptideScanId(peptide: string) {
+    this.selectedPeptideScanId = peptide;
   }
 
   setPrecursorCharge(charge: number) {


### PR DESCRIPTION
This PR modifies the PeptideSelect component and PeptideStore in the following ways:

1. Changes `setSelectedPeptide` method in `PeptideStore` to `setSelectedPeptideScanId` for better semantics.
2. Updates the PeptideSelect component to use `selectedPeptideScanId` instead of `selectedPeptide` for clearer handling of peptide scans.
3. Adds a computed MobX function to retrieve the selected peptide based on the scan ID.
4. Modifies the dropdown display to show the peptide sequence or a placeholder when none is selected.

### How to test?
1. Ensure the application starts without errors.
2. Load a peptide CSV file.
3. Use the peptide select dropdown to confirm that selecting a peptide updates based on the scan ID and displays correctly.
